### PR TITLE
Refactor jekyll posts and add rss

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,5 @@ title: GCC Front-End For Rust
 description: Alternative Rust Compiler for GCC
 logo: /images/logo.png
 theme: jekyll-theme-minimal
+plugins:
+  - jekyll-feed

--- a/_posts/2022-11-01-2022-10-monthly-report.md
+++ b/_posts/2022-11-01-2022-10-monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "October 2022 monthly report"
-author: Arthur Cohen
+author: Philip Herron and Arthur Cohen
 tags:
     - monthly-report
 ---

--- a/_posts/2022-11-01-2022-10-monthly-report.md
+++ b/_posts/2022-11-01-2022-10-monthly-report.md
@@ -1,3 +1,11 @@
+---
+layout: post
+title: "October 2022 monthly report"
+author: Arthur Cohen
+tags:
+    - monthly-report
+---
+
 ## Overview
 
 Thanks again to [Open Source Security, inc](https://opensrcsec.com/) and

--- a/_posts/2022-12-01-2022-11-monthly-report.md
+++ b/_posts/2022-12-01-2022-11-monthly-report.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "November 2022 monthly report"
-author: Arthur Cohen
+author: Philip Herron and Arthur Cohen
 tags:
     - monthly-report
 ---

--- a/_posts/2022-12-01-2022-11-monthly-report.md
+++ b/_posts/2022-12-01-2022-11-monthly-report.md
@@ -1,3 +1,11 @@
+---
+layout: post
+title: "November 2022 monthly report"
+author: Arthur Cohen
+tags:
+    - monthly-report
+---
+
 ## Overview
 
 Thanks again to [Open Source Security, inc](https://opensrcsec.com/) and

--- a/_posts/2023-01-01-2022-year-report.md
+++ b/_posts/2023-01-01-2022-year-report.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "2022 Yearly report"
-author: Arthur Cohen
+author: Philip Herron and Arthur Cohen
 tags:
     - yearly-report
 ---

--- a/_posts/2023-01-01-2022-year-report.md
+++ b/_posts/2023-01-01-2022-year-report.md
@@ -1,3 +1,11 @@
+---
+layout: post
+title: "2022 Yearly report"
+author: Arthur Cohen
+tags:
+    - yearly-report
+---
+
 # Overview
 
 Thanks again to [Open Source Security, inc](https://opensrcsec.com/) and

--- a/index.md
+++ b/index.md
@@ -15,8 +15,9 @@ You can find compiler status reports over on: [https://github.com/Rust-GCC/Repor
 
 ## Status reports
 
+{% assign sorted_posts = site.posts | sort: "date" | reverse %}
 <ul>
-  {% for post in site.posts %}
+  {% for post in sorted_posts %}
     <li>
       <a href="{{ post.url }}">{{ post.title }}</a>
     </li>

--- a/index.md
+++ b/index.md
@@ -1,4 +1,9 @@
-## GCC Front-End For Rust
+---
+layout: default
+title: GCC Front-End For Rust
+---
+
+# GCC Front-End For Rust
 
 This is a full alternative implementation of the Rust language on top of GCC with the goal to become fully upstream with the GNU toolchain.
 
@@ -10,9 +15,13 @@ You can find compiler status reports over on: [https://github.com/Rust-GCC/Repor
 
 ## Status reports
 
-* [2022 Yearly report](/reporting/2022-year-report.md)
-* [November 2022 monthly report](/reporting/2022-11-monthly-report.md)
-* [October 2022 monthly report](/reporting/2022-10-monthly-report.md)
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
 
 ### FAQ
 
@@ -46,3 +55,7 @@ As this is destined to be upstreamed to GCC we require copyright assignment: [ht
 * Github: [https://github.com/Rust-GCC](https://github.com/Rust-GCC)
 * Zulip: [https://gcc-rust.zulipchat.com/](https://gcc-rust.zulipchat.com/)
 * Twitter: [https://twitter.com/gcc_rust](https://twitter.com/gcc_rust)
+
+### RSS
+
+You can stay updated on our progress with this [RSS feed](/feed.xml).


### PR DESCRIPTION
I moved the reporting folder to `_posts` and added some metadata like author and tags to follow Jekyll's architecture.

This PR also adds the RSS feed to stay updated on your work guys :wink: 