### PR TITLE
Remove requirement for copyright assignment

### DIFF
--- a/index.md
+++ b/index.md
@@ -51,8 +51,6 @@ Please feel free to raise a PR to add your names.
 
 ### Get Involved
 
-As this is destined to be upstreamed to GCC we require copyright assignment: [https://gcc.gnu.org/contribute.html](https://gcc.gnu.org/contribute.html). Not all contributions must be code, please try it out and feed us bugs.
-
 * Github: [https://github.com/Rust-GCC](https://github.com/Rust-GCC)
 * Zulip: [https://gcc-rust.zulipchat.com/](https://gcc-rust.zulipchat.com/)
 * Twitter: [https://twitter.com/gcc_rust](https://twitter.com/gcc_rust)


### PR DESCRIPTION
This statement is no longer valid and DCO is allowed.