### PR TITLE
:pencil2: Fix missing repo in pull request links in 2025-06-04-2025-05-monthly-report.md

### DIFF
--- a/_posts/2025-06-04-2025-05-monthly-report.md
+++ b/_posts/2025-06-04-2025-05-monthly-report.md
@@ -79,57 +79,57 @@ upcoming events.
 ## Completed Activities
 
 -   gccrs: Always emit the error highest in the type hierarchy
-    [PR3809](https://github.com/rust-gcc/pull/3809)
+    [PR3809](https://github.com/Rust-GCC/gccrs/pull/3809)
 -   Adjust included headers in \`rust-lang.cc\`
-    [PR3808](https://github.com/rust-gcc/pull/3808)
+    [PR3808](https://github.com/Rust-GCC/gccrs/pull/3808)
 -   gccrs: Initial support for Return Position Impl Trait
-    [PR3807](https://github.com/rust-gcc/pull/3807)
+    [PR3807](https://github.com/Rust-GCC/gccrs/pull/3807)
 -   gccrs: refactor default infer vars to be its own function
-    [PR3806](https://github.com/rust-gcc/pull/3806)
+    [PR3806](https://github.com/Rust-GCC/gccrs/pull/3806)
 -   gccrs: Remove unneeded clones untill we have an arena allocator for
-    these temps [PR3805](https://github.com/rust-gcc/pull/3805)
+    these temps [PR3805](https://github.com/Rust-GCC/gccrs/pull/3805)
 -   nr2.0: Fix some paths in test files
-    [PR3803](https://github.com/rust-gcc/pull/3803)
+    [PR3803](https://github.com/Rust-GCC/gccrs/pull/3803)
 -   nr2.0: Fix \`IfLet\` pattern handling
-    [PR3802](https://github.com/rust-gcc/pull/3802)
+    [PR3802](https://github.com/Rust-GCC/gccrs/pull/3802)
 -   nr2.0: Fix test \`builtin<sub>abort</sub>.rs\`
-    [PR3800](https://github.com/rust-gcc/pull/3800)
+    [PR3800](https://github.com/Rust-GCC/gccrs/pull/3800)
 -   Remove rvalue reference binding
-    [PR3795](https://github.com/rust-gcc/pull/3795)
--   Remove unused file [PR3794](https://github.com/rust-gcc/pull/3794)
+    [PR3795](https://github.com/Rust-GCC/gccrs/pull/3795)
+-   Remove unused file [PR3794](https://github.com/Rust-GCC/gccrs/pull/3794)
 -   gccrs: Fix NR2 ICE in visit<sub>attributes</sub>
-    [PR3793](https://github.com/rust-gcc/pull/3793)
+    [PR3793](https://github.com/Rust-GCC/gccrs/pull/3793)
 -   gccrs: We cant clone types as it will dup the node-id
-    [PR3792](https://github.com/rust-gcc/pull/3792)
+    [PR3792](https://github.com/Rust-GCC/gccrs/pull/3792)
 -   Fix \`Attr\` metavariable binding
-    [PR3790](https://github.com/rust-gcc/pull/3790)
+    [PR3790](https://github.com/Rust-GCC/gccrs/pull/3790)
 -   nr2.0: Fix borrow checking
-    [PR3789](https://github.com/rust-gcc/pull/3789)
+    [PR3789](https://github.com/Rust-GCC/gccrs/pull/3789)
 -   Fix test \`same<sub>fieldname</sub>.rs\`
-    [PR3788](https://github.com/rust-gcc/pull/3788)
+    [PR3788](https://github.com/Rust-GCC/gccrs/pull/3788)
 -   Adapt attribute lang hook and do some cleanup
-    [PR3786](https://github.com/rust-gcc/pull/3786)
+    [PR3786](https://github.com/Rust-GCC/gccrs/pull/3786)
 -   Small improvements to \`DefaultASTVisitor\` and nr2.0
-    [PR3784](https://github.com/rust-gcc/pull/3784)
+    [PR3784](https://github.com/Rust-GCC/gccrs/pull/3784)
 -   Fix ICE segfault on empty static loops
-    [PR3781](https://github.com/rust-gcc/pull/3781)
+    [PR3781](https://github.com/Rust-GCC/gccrs/pull/3781)
 -   gccrs: Prevent passing generic arguments to impl traits in argument
-    position [PR3780](https://github.com/rust-gcc/pull/3780)
+    position [PR3780](https://github.com/Rust-GCC/gccrs/pull/3780)
 -   ast: collect InlineAsm node dump
-    [PR3779](https://github.com/rust-gcc/pull/3779)
+    [PR3779](https://github.com/Rust-GCC/gccrs/pull/3779)
 -   gccrs: desugar APIT impl traits
-    [PR3778](https://github.com/rust-gcc/pull/3778)
+    [PR3778](https://github.com/Rust-GCC/gccrs/pull/3778)
 -   gccrs: Emit error diagnostic for bad impl type usage
-    [PR3777](https://github.com/rust-gcc/pull/3777)
+    [PR3777](https://github.com/Rust-GCC/gccrs/pull/3777)
 -   nr2.0: Adjust enum item visitors
-    [PR3775](https://github.com/rust-gcc/pull/3775)
+    [PR3775](https://github.com/Rust-GCC/gccrs/pull/3775)
 -   Improve canonical path handling for impl items
-    [PR3774](https://github.com/rust-gcc/pull/3774)
+    [PR3774](https://github.com/Rust-GCC/gccrs/pull/3774)
 -   Improve struct pattern compilation
-    [PR3773](https://github.com/rust-gcc/pull/3773)
+    [PR3773](https://github.com/Rust-GCC/gccrs/pull/3773)
 -   nr2.0: Adjust resolution of impl items
-    [PR3768](https://github.com/rust-gcc/pull/3768)
--   Handle const blocks [PR3738](https://github.com/rust-gcc/pull/3738)
+    [PR3768](https://github.com/Rust-GCC/gccrs/pull/3768)
+-   Handle const blocks [PR3738](https://github.com/Rust-GCC/gccrs/pull/3738)
 
 ### Contributors this month
 


### PR DESCRIPTION
About the `rust-gcc` to `Rust-GCC` change: both works, but when navigating GitHub will use the cased one.